### PR TITLE
[refactor][m]: refactor code to use the new skd adjustments - #17

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "axios": "^0.19.2",
-    "ckan3-js-sdk": "datopian/ckan3-js-sdk",
+    "ckanClient": "git+https://github.com/datopian/ckan-client-js",
     "data.js": "git+https://github.com/datopian/data.js.git",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/App.css
+++ b/src/App.css
@@ -31,7 +31,7 @@ code {
   min-height: 60%;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto  500px auto auto;
+  grid-template-rows: auto  300px auto auto;
   grid-template-areas:
     "header header"
     "uploadArea uploadArea"

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Uploader, FileAPI } from "ckan3-js-sdk";
+import { Client, Open  } from "ckanClient";
 import data from "data.js";
 import toArray from "stream-to-array";
 import PropTypes from "prop-types";
@@ -74,9 +74,9 @@ class Upload extends React.Component {
     const { authToken, api, organizationId, datasetId } = config;
 
     // create an instance of a object
-    const file = new FileAPI.HTML5File(selectedFile);
+    const file = new Open.HTML5File(selectedFile);
 
-    const uploader = new Uploader(
+    const client = new Client(
       `${authToken}`,
       `${organizationId}`,
       `${datasetId}`,
@@ -90,21 +90,9 @@ class Upload extends React.Component {
     });
 
     // Get the JWT token from authz and upload file to the storage
-    fetch(`${authzUrl}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: authToken,
-      },
-      body: JSON.stringify(scopes),
-    })
-      .then((response) => response.json())
-      .then((response) =>
-        uploader.push(file, response.result.token, this.onUploadProgress)
-      )
-      .then((response) =>
-        this.setState({ success: response.success, loading: false })
-      )
+    client.ckanAuthz(`${authzUrl}`)
+      .then((response) => client.push(file, response.result.token, this.onUploadProgress))
+      .then((response) => this.setState({ success: response.success, loading: false }))
       .catch((error) => this.setState({ error: true, loading: false }));
   };
 
@@ -170,7 +158,7 @@ Upload.defaultProps = {
   scopes: {
     scopes: [`obj:myorg/data-test-2/*:read,write`],
   },
-  authzUrl: "http://localhost:5000/api/action/authz_authorize",
+  authzUrl: "http://localhost:5000",
 };
 
 Upload.propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6224,9 +6224,9 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-ckan3-js-sdk@datopian/ckan3-js-sdk:
+"ckanClient@git+https://github.com/datopian/ckan-client-js":
   version "1.0.0"
-  resolved "https://codeload.github.com/datopian/ckan3-js-sdk/tar.gz/010eb8bbc4eb81ffbaefccc9245db8d596ffe8c3"
+  resolved "git+https://github.com/datopian/ckan-client-js#1edf3373dce9449c453b44aae25bda6c1284f538"
   dependencies:
     axios "^0.19.2"
     crypto-js "^4.0.0"


### PR DESCRIPTION
@anuveyatsu  I refactored the code to be able to use new SDK adjustments. 
I did a real test to send a file to the storage and show de table schema and it works properly. You can see better in the gif below.
cc: @rufuspollock @kmanaseryan 

**Result:**
![tableschema](https://user-images.githubusercontent.com/24671133/92937900-4a401300-f422-11ea-947f-38f20c993e43.gif)

