### PR TITLE
[refactor][m]: refactor to use the SDK updates - #27

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "axios": "^0.19.2",
     "ckanClient": "git+https://github.com/datopian/ckan-client-js",
     "data.js": "git+https://github.com/datopian/data.js.git",
+    "frictionless-ckan-mapper-js": "^1.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "axios": "^0.19.2",
-    "ckanClient": "git+https://github.com/datopian/ckan-client-js",
+    "ckanClient": "git+https://github.com/datopian/ckan-client-js.git",
     "data.js": "git+https://github.com/datopian/data.js.git",
     "frictionless-ckan-mapper-js": "^1.0.0",
     "react": "^16.13.1",

--- a/src/App.js
+++ b/src/App.js
@@ -30,13 +30,14 @@ export class ResourceEditor extends React.Component {
 
   componentWillMount() {
     const { config } = this.props;
-    const { authToken, api, organizationId, datasetId } = config;
+    const { authToken, api, lfs, organizationId, datasetId } = config;
 
     const client = new Client(
       `${authToken}`,
       `${organizationId}`,
       `${datasetId}`,
-      `${api}`
+      `${api}`,
+      `${lfs}`
     );
     this.setState({client})
   }
@@ -142,6 +143,7 @@ export class ResourceEditor extends React.Component {
   config: {
     authToken: "be270cae-1c77-4853-b8c1-30b6cf5e9878",
     api: "http://localhost:5000",
+    lfs: "http://localhost:5001", // Feel free to modify this
     organizationId: "myorg",
     datasetId: "data-test-2",
   },

--- a/src/App.js
+++ b/src/App.js
@@ -91,7 +91,12 @@ export class ResourceEditor extends React.Component {
             <h2 className="upload-header__title">Resource Editor</h2>
           </div>
 
-          <Upload client={this.state.client} resource={this.state.resource} metadataHandler={this.metadataHandler} />
+          <Upload
+            client={this.state.client}
+            resource={this.state.resource}
+            metadataHandler={this.metadataHandler}
+            datasetId={this.state.datasetId}
+          />
 
           <div className="upload-switcher">
             <Switcher

--- a/src/App.js
+++ b/src/App.js
@@ -21,9 +21,9 @@ export class ResourceEditor extends React.Component {
         success: false,
         error: false,
         loading: false,
-        metadataOrSchema: 'metadata',
-        client: ''
-      }
+        metadataOrSchema: 'metadata'
+      },
+      client: null
     };
     this.metadataHandler = this.metadataHandler.bind(this);
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Client } from "ckanClient";
 import PropTypes from "prop-types";
-import frictionlessCkanMapper from "frictionless-ckan-mapper-js";
 
 import Metadata from "./components/Metadata";
 import TableSchema from "./components/TableSchema";
@@ -66,13 +65,13 @@ export class ResourceEditor extends React.Component {
     event.preventDefault();
 
     const { resource, client } = this.state;
-    // Update resource
-    const ckanResource = frictionlessCkanMapper.resourceFrictionlessToCkan(
-      resource.descriptor
-    )
-    client.action('resource_update', Object.assign(ckanResource, {
-      package_id: this.state.datasetId
-    }))
+    // Save resource metadata updates (including schema)
+    const datasetMetadata = client.retrieve(this.state.datasetId);
+    // Here we're only handling single resource but in the future we need to
+    // refactor this to manage multiple resources:
+    datasetMetadata.resources[0] = resource.descriptor;
+    // TODO: do we need to remove 'sample' attribute from resource descriptor?
+    client.push(datasetMetadata);
   };
 
   switcher = (name) => {

--- a/src/App.js
+++ b/src/App.js
@@ -61,15 +61,17 @@ export class ResourceEditor extends React.Component {
     });
   };
 
-  handleSubmitMetadata = (event, index) => {
+  handleSubmitMetadata = async (event, index) => {
     event.preventDefault();
 
     const { resource, client } = this.state;
     // Save resource metadata updates (including schema)
-    const datasetMetadata = client.retrieve(this.state.datasetId);
+    const datasetMetadata = await client.retrieve(this.state.datasetId);
+
     // Here we're only handling single resource but in the future we need to
     // refactor this to manage multiple resources:
-    datasetMetadata.resources[0] = resource.descriptor;
+    delete resource.sample;
+    datasetMetadata.resources.push(resource);
     // TODO: do we need to remove 'sample' attribute from resource descriptor?
     client.push(datasetMetadata);
   };

--- a/src/App.js
+++ b/src/App.js
@@ -65,11 +65,13 @@ export class ResourceEditor extends React.Component {
     event.preventDefault();
 
     const { resource, client } = this.state;
-    // create new resource variable and delete _values
-    const newResource = resource
-    delete newResource.sample
-
-    client.push(newResource)
+    // Update resource
+    const ckanResource = frictionlessCkanMapper.resourceFrictionlessToCkan(
+      resource.descriptor
+    )
+    client.action('resource_update', Object.assign(ckanResource, {
+      package_id: this.state.datasetId
+    }))
   };
 
   switcher = (name) => {

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Client } from "ckanClient";
 import PropTypes from "prop-types";
+import frictionlessCkanMapper from "frictionless-ckan-mapper-js";
 
 import Metadata from "./components/Metadata";
 import TableSchema from "./components/TableSchema";

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import { Client } from "ckanClient";
+import PropTypes from "prop-types";
+
 import Metadata from "./components/Metadata";
 import TableSchema from "./components/TableSchema";
 import Switcher from "./components/Switcher";
@@ -18,10 +21,24 @@ export class ResourceEditor extends React.Component {
         success: false,
         error: false,
         loading: false,
-        metadataOrSchema: 'metadata'
+        metadataOrSchema: 'metadata',
+        client: ''
       }
     };
     this.metadataHandler = this.metadataHandler.bind(this);
+  }
+
+  componentWillMount() {
+    const { config } = this.props;
+    const { authToken, api, organizationId, datasetId } = config;
+
+    const client = new Client(
+      `${authToken}`,
+      `${organizationId}`,
+      `${datasetId}`,
+      `${api}`
+    );
+    this.setState({client})
   }
 
   metadataHandler(resource) {
@@ -46,7 +63,13 @@ export class ResourceEditor extends React.Component {
 
   handleSubmitMetadata = (event, index) => {
     event.preventDefault();
-    console.log("Metadata state: ", this.state.resource);
+
+    const { resource, client } = this.state;
+    // create new resource variable and delete _values
+    const newResource = resource
+    delete newResource._values
+  
+    client.push(newResource)
   };
 
   handleSubmitSchema = (schema, index) => {
@@ -72,7 +95,7 @@ export class ResourceEditor extends React.Component {
             <h2 className="upload-header__title">Resource Editor</h2>
           </div>
 
-          <Upload resource={this.state.resource} metadataHandler={this.metadataHandler} />
+          <Upload client={this.state.client} resource={this.state.resource} metadataHandler={this.metadataHandler} />
 
           <div className="upload-switcher">
             <Switcher
@@ -105,5 +128,22 @@ export class ResourceEditor extends React.Component {
     );
   }
 }
+
+/**
+ * If the parent component doesn't specify a `config` and scope prop, then
+ * the default values will be used.
+ * */
+ ResourceEditor.defaultProps = {
+  config: {
+    authToken: "be270cae-1c77-4853-b8c1-30b6cf5e9878",
+    api: "http://localhost:5000",
+    organizationId: "myorg",
+    datasetId: "data-test-2",
+  },
+};
+
+ResourceEditor.propTypes = {
+  config: PropTypes.object.isRequired,
+};
 
 export default ResourceEditor;

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ export class ResourceEditor extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      datasetId: this.props.datasetId,
+      datasetId: this.props.config.datasetId,
       resource: this.props.resource || {},
       ui: {
         fileOrLink: '',

--- a/src/components/TableSchema/index.jsx
+++ b/src/components/TableSchema/index.jsx
@@ -24,9 +24,9 @@ const TableSchema = (props) => {
   } = useTable({ columns, data });
 
   const handleChange = (event, key, index) => {
-    let newObj = [...schema];
-    newObj[index][key] = event.target.value;
-    setSchema(newObj);
+    const newSchema = {...schema};
+    newSchema.fields[index][key] = event.target.value;
+    setSchema(newSchema);
   };
 
   const renderEditSchemaField = (key) => {

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -35,7 +35,7 @@ class Upload extends React.Component {
         console.error(e);
       }
       formattedSize = onFormatBytes(file.size);
-      const hash = await file.hash();
+      const hash = await file.hashSha256();
       this.props.metadataHandler(Object.assign(file.descriptor, {hash}))
     }
 

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
-import f11s from "data.js"
+import data from "data.js";
+import frictionlessCkanMapper from 'frictionless-ckan-mapper-js';
 import toArray from "stream-to-array";
 import ProgressBar from "../ProgressBar";
 import { onFormatBytes } from '../../utils';
@@ -74,7 +75,7 @@ class Upload extends React.Component {
     const { selectedFile } = this.state;
     const { client } = this.props;
 
-    const resource = f11s.open(selectedFile)
+    const resource = data.open(selectedFile)
 
     this.setState({
       fileSize: resource.size,
@@ -85,7 +86,13 @@ class Upload extends React.Component {
     // Use client to upload file to the storage and track the progress
     client.pushBlob(resource, this.onUploadProgress)
       .then((response) => this.setState({ success: response.success, loading: false }))
-      .then(() => client.create(resource))
+      .then(() => {
+        // Once upload is done, create a resource
+        const ckanResource = frictionlessCkanMapper.resourceFrictionlessToCkan(
+          resource.descriptor
+        )
+        client.action('resource_create', ckanResource)
+      })
       .catch((error) => this.setState({ error: true, loading: false }));
   };
 

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -92,6 +92,7 @@ class Upload extends React.Component {
         const ckanResource = frictionlessCkanMapper.resourceFrictionlessToCkan(
           resource.descriptor
         )
+        delete ckanResource.sample
         client.action('resource_create', Object.assign(ckanResource, {
           package_id: this.state.datasetId
         }))

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -10,6 +10,7 @@ class Upload extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      datasetId: props.datasetId,
       selectedFile: null,
       fileSize: 0,
       formattedSize: "0 KB",
@@ -91,7 +92,9 @@ class Upload extends React.Component {
         const ckanResource = frictionlessCkanMapper.resourceFrictionlessToCkan(
           resource.descriptor
         )
-        client.action('resource_create', ckanResource)
+        client.action('resource_create', Object.assign(ckanResource, {
+          package_id: this.state.datasetId
+        }))
       })
       .catch((error) => this.setState({ error: true, loading: false }));
   };

--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { Client, Open  } from "ckanClient";
-import data from "data.js";
+import f11s from "data.js"
 import toArray from "stream-to-array";
-import PropTypes from "prop-types";
 import ProgressBar from "../ProgressBar";
 import { onFormatBytes } from '../../utils';
 import Choose from "../Choose";
@@ -28,7 +26,7 @@ class Upload extends React.Component {
 
     if (event.target.files.length > 0) {
       selectedFile = event.target.files[0];
-      const file = data.open(selectedFile);
+      const file = f11s.open(selectedFile);
       const rowStream = await file.rows({size: 20, keyed: true});
       file.descriptor._values = await toArray(rowStream);
       await file.addSchema();
@@ -70,29 +68,20 @@ class Upload extends React.Component {
   onClickHandler = async () => {
     const start = new Date().getTime();
     const { selectedFile } = this.state;
-    const { scopes, config, authzUrl } = this.props;
-    const { authToken, api, organizationId, datasetId } = config;
+    const { client } = this.props;
 
-    // create an instance of a object
-    const file = new Open.HTML5File(selectedFile);
-
-    const client = new Client(
-      `${authToken}`,
-      `${organizationId}`,
-      `${datasetId}`,
-      `${api}`
-    );
+    const resource = f11s.open(selectedFile)
 
     this.setState({
-      fileSize: file.size(),
+      fileSize: resource.size,
       start,
       loading: true,
     });
 
-    // Get the JWT token from authz and upload file to the storage
-    client.ckanAuthz(`${authzUrl}`)
-      .then((response) => client.push(file, response.result.token, this.onUploadProgress))
+    // Use client to upload file to the storage and track the progress
+    client.pushBlob(resource, this.onUploadProgress)
       .then((response) => this.setState({ success: response.success, loading: false }))
+      .then(() => client.create(resource))
       .catch((error) => this.setState({ error: true, loading: false }));
   };
 
@@ -143,28 +132,5 @@ class Upload extends React.Component {
     );
   }
 }
-
-/**
- * If the parent component doesn't specify a `config` and scope prop, then
- * the default values will be used.
- * */
-Upload.defaultProps = {
-  config: {
-    authToken: "be270cae-1c77-4853-b8c1-30b6cf5e9878",
-    api: "http://localhost:9419",
-    organizationId: "myorg",
-    datasetId: "data-test-2",
-  },
-  scopes: {
-    scopes: [`obj:myorg/data-test-2/*:read,write`],
-  },
-  authzUrl: "http://localhost:5000",
-};
-
-Upload.propTypes = {
-  config: PropTypes.object.isRequired,
-  scopes: PropTypes.object.isRequired,
-  authzUrl: PropTypes.string.isRequired,
-};
 
 export default Upload;

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,15 @@ import App from './App';
 
 // Mount the ResourceEditor app explicitly
 // (make sure you call the function after it's loaded)
-function mountResourceEditorApp([elementId, datasetId] = ['root', undefined]) {
-  if (!datasetId) {
-    throw Error('Dataset id is required.')
-  }
-
+function mountResourceEditorApp([elementId, config, resource] = ['root', {
+  authToken: null,
+  api: null,
+  organizationId: null,
+  datasetId: null
+}, {}]) {
   ReactDOM.render(
     <React.StrictMode>
-      <App datasetId={datasetId} />
+      <App config={config} resource={resource} />
     </React.StrictMode>,
     document.getElementById(elementId)
   );
@@ -22,10 +23,17 @@ function mountResourceEditorApp([elementId, datasetId] = ['root', undefined]) {
 // Automatically mount the app if an element with id='ResourceEditor' exists
 const element = document.getElementById('ResourceEditor');
 if (element) {
+  const config = {
+    datasetId: element.getAttribute('data-dataset-id')
+    api: element.getAttribute('data-api')
+    authToken: element.getAttribute('data-auth-token')
+    organizationId: element.getAttribute('data-organization-id')
+  }
+
   ReactDOM.render(
     <React.StrictMode>
       <App
-        datasetId={ element.getAttribute('data-dataset-id') }
+        config={config}
         resource={ element.getAttribute('data-resource')}
       />
     </React.StrictMode>,

--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,9 @@ function mountResourceEditorApp([elementId, config, resource] = ['root', {
 const element = document.getElementById('ResourceEditor');
 if (element) {
   const config = {
-    datasetId: element.getAttribute('data-dataset-id')
-    api: element.getAttribute('data-api')
-    authToken: element.getAttribute('data-auth-token')
+    datasetId: element.getAttribute('data-dataset-id'),
+    api: element.getAttribute('data-api'),
+    authToken: element.getAttribute('data-auth-token'),
     organizationId: element.getAttribute('data-organization-id')
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import App from './App';
 function mountResourceEditorApp([elementId, config, resource] = ['root', {
   authToken: null,
   api: null,
+  lfs: null,
   organizationId: null,
   datasetId: null
 }, {}]) {
@@ -26,6 +27,7 @@ if (element) {
   const config = {
     datasetId: element.getAttribute('data-dataset-id'),
     api: element.getAttribute('data-api'),
+    lfs: element.getAttribute('data-lfs'),
     authToken: element.getAttribute('data-auth-token'),
     organizationId: element.getAttribute('data-organization-id')
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7105,8 +7105,8 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-url "^7.0.0"
 
 "data.js@git+https://github.com/datopian/data.js.git":
-  version "0.12.11"
-  resolved "git+https://github.com/datopian/data.js.git#41005e354d44c20505466ef7735bdecade84b4cc"
+  version "0.13.0"
+  resolved "git+https://github.com/datopian/data.js.git#82b026a481d33ea0a620f5afb52a30588cd5c753"
   dependencies:
     "@babel/polyfill" "^7.4.4"
     browserify "^16.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6231,6 +6231,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     axios "^0.19.2"
     crypto-js "^4.0.0"
 
+"ckanClient@git+https://github.com/datopian/ckan-client-js.git":
+  version "0.2.0"
+  resolved "git+https://github.com/datopian/ckan-client-js.git#b3cb22401aab0cd1cb08c5517d8ed30da53df305"
+  dependencies:
+    axios "^0.19.2"
+    crypto-js "^4.0.0"
+    frictionless-ckan-mapper-js "^1.0.0"
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6224,16 +6224,9 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-"ckanClient@git+https://github.com/datopian/ckan-client-js":
-  version "1.0.0"
-  resolved "git+https://github.com/datopian/ckan-client-js#1edf3373dce9449c453b44aae25bda6c1284f538"
-  dependencies:
-    axios "^0.19.2"
-    crypto-js "^4.0.0"
-
 "ckanClient@git+https://github.com/datopian/ckan-client-js.git":
   version "0.2.0"
-  resolved "git+https://github.com/datopian/ckan-client-js.git#b3cb22401aab0cd1cb08c5517d8ed30da53df305"
+  resolved "git+https://github.com/datopian/ckan-client-js.git#47c99604aa5f300f732f25cfa8fc0032354b1169"
   dependencies:
     axios "^0.19.2"
     crypto-js "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7105,7 +7105,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
 
 "data.js@git+https://github.com/datopian/data.js.git":
   version "0.12.11"
-  resolved "git+https://github.com/datopian/data.js.git#3adb84d1cdf21345a0b87f82cb0ff7a005f3c90f"
+  resolved "git+https://github.com/datopian/data.js.git#41005e354d44c20505466ef7735bdecade84b4cc"
   dependencies:
     "@babel/polyfill" "^7.4.4"
     browserify "^16.5.2"
@@ -8759,6 +8759,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+frictionless-ckan-mapper-js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/frictionless-ckan-mapper-js/-/frictionless-ckan-mapper-js-1.0.0.tgz#856b5bcad12bfbeb72084219fba621aca211700a"
+  integrity sha512-/6/5ECgB1sBuKmgbeXHFi4yiSudZszaGUOhlbsqMybGy9IAFwPX8Pu6rqN7aXjTvzWTUJ0bTh2LsNaB9EuPugQ==
 
 from2@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
Refactor due to recent updates in ckan-client-js so we can create/update resources + push to blob.

Acceptance

- [x] Refactor react code to use the recent updates in the SDK

Tasks that I did:

- Now I created a instance of the client in the `ResourceEditor` component into `componentWillMount()` so the `client` will be available for all components
- Edited the `handleSubmitMetadata()` function to use `client.push(resource)` to update the metada, when the user submit the form
- Edited the `onClickHandler()` function to use the new updates to push blob to storage and if the upload status is success, will call the `client.create(resource)` function.