### PR TITLE
Remove step process and show schema editor always

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,8 +112,8 @@ code {
   grid-area: editArea;
 }
 
-
 .btn {
+  max-width: 220px;
   margin: 2rem;
   border-radius: 5px;
   padding: 10px 25px;
@@ -157,4 +157,9 @@ code {
 
 .btn-delete:hover {
   background-color: #C70E00;
+}
+
+.resource-edit-actions {
+  display: flex;
+  justify-content: space-between;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -33,7 +33,6 @@ code {
   grid-template-areas:
     "header header"
     "uploadArea uploadArea"
-    "switcher switcher"
     "editArea editArea";
   row-gap: 20px;
   column-gap: 20px;

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ export class ResourceEditor extends React.Component {
         success: false,
         error: false,
         loading: false,
-        metadataOrSchema: 'metadata'
       },
       client: null,
       isResourceEdit: false,
@@ -98,8 +97,7 @@ export class ResourceEditor extends React.Component {
     });
   };
 
-  handleSubmitMetadata = async (event, index) => {
-    event.preventDefault();
+  handleSubmitMetadata = async (index) => {
 
     const { resource, client } = this.state;
 
@@ -207,7 +205,6 @@ export class ResourceEditor extends React.Component {
     const {
       loading,
       success,
-      metadataOrSchema,
     } = this.state.ui;
 
     return (
@@ -226,34 +223,23 @@ export class ResourceEditor extends React.Component {
             onChangeResourceId={this.onChangeResourceId}
           />
 
-          <div className="upload-switcher">
-            <Switcher
-              metadataOrSchema={metadataOrSchema}
-              switcher={this.switcher}
-            />
-          </div>
-
           <div className="upload-edit-area">
-            {metadataOrSchema === 'metadata' && (
               <Metadata
                 loading={loading}
                 uploadSuccess={success}
                 metadata={this.state.resource}
-                handleSubmit={this.handleSubmitMetadata}
                 handleChange={this.handleChangeMetadata}
                 isResourceEdit={this.state.isResourceEdit}
                 deleteResource={this.deleteResource}
                 updateResource={this.createResource}
               />
-            )}
-            {metadataOrSchema === 'schema' && (
               <TableSchema
                 schema={this.state.resource.schema || {fields: []}}
                 data={
                   this.state.resource.sample || []
                 }
               />
-            )}
+              <button  disabled={!success} className="btn" onClick={this.handleSubmitMetadata}>Save and Publish</button>
           </div>
         </div>
       </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import App from "./App";
+
+describe("<App />", () => {
+
+    it("should render in add a resource", () => {
+        const wrapper = shallow(<App/>);
+
+        expect(wrapper.find(".btn")).toHaveLength(1)
+        expect(wrapper.find(".btn-delete")).toHaveLength(0)
+    });
+})

--- a/src/components/Metadata/Metadata.css
+++ b/src/components/Metadata/Metadata.css
@@ -41,10 +41,11 @@
   box-sizing: border-box;
 }
 
-.metadata-btn {
+.btn {
   margin-top: 17px;
   border-radius: 5px;
-  padding: 10px 25px;
+  padding: 10px;
+  width: 50%;
   height: 45px;
   font-size: 1.2rem;
   color: #fff;
@@ -55,11 +56,11 @@
   box-shadow: 0 4px 11px 3px rgba(18, 22, 33, 0.05);
 }
 
-.metadata-btn:disabled {
+.btn:disabled {
   background: #e3e9ed !important;
   cursor: default;
 }
 
-.metadata-btn:hover {
+.btn:hover {
   background-color: #009ace;
 }

--- a/src/components/Metadata/Metadata.test.js
+++ b/src/components/Metadata/Metadata.test.js
@@ -56,21 +56,4 @@ describe("<Metadata />", () => {
     expect(inputRestricted.props().value).toEqual("private");
     expect(inputEncoding.props().value).toEqual("utf-8");
   });
-
-  it("should render in edit mode", () => {
-    const wrapper = shallow(
-      <Metadata
-        metadata={{}}
-        handleChange={handleChange}
-        handleSubmit={handleSubmit}
-        deleteResource={deleteResource}
-        updateResource={updateResource}
-        uploadSuccess={false}
-        isResourceEdit={true}
-      />
-    );
-
-    expect(wrapper.find(".btn")).toHaveLength(2)
-    expect(wrapper.find(".btn-delete")).toHaveLength(1)
-  });
 });

--- a/src/components/Metadata/index.jsx
+++ b/src/components/Metadata/index.jsx
@@ -5,6 +5,7 @@ import "./Metadata.css";
 import encodeData from "../../db/encode.json";
 import formatData from "../../db/resource_formats.json";
 
+<<<<<<< HEAD
 //TODO: add the custom fields as a props and render it in metadata component
 const customFields = [
   {
@@ -30,6 +31,13 @@ const Metadata = ({ metadata, handleChange, handleSubmit, uploadSuccess, isResou
           return handleSubmit(event, 0)
         }}
       >
+=======
+const Metadata = ({ metadata, handleChange, uploadSuccess }) => {
+  return (
+    <>
+      <h3 className="metadata-name">{metadata.path}</h3>
+      <form className="metadata-form">
+>>>>>>> [ui][s] removed switcher and update css styles - #39
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="title">
             Title:
@@ -150,7 +158,6 @@ const Metadata = ({ metadata, handleChange, handleSubmit, uploadSuccess, isResou
 Metadata.propTypes = {
   metadata: PropTypes.object.isRequired,
   handleChange: PropTypes.func.isRequired,
-  handleSubmit: PropTypes.func.isRequired,
   uploadSuccess: PropTypes.bool.isRequired,
   isResourceEdit: PropTypes.bool.isRequired,
   deleteResource: PropTypes.func.isRequired,

--- a/src/components/Metadata/index.jsx
+++ b/src/components/Metadata/index.jsx
@@ -5,7 +5,6 @@ import "./Metadata.css";
 import encodeData from "../../db/encode.json";
 import formatData from "../../db/resource_formats.json";
 
-<<<<<<< HEAD
 //TODO: add the custom fields as a props and render it in metadata component
 const customFields = [
   {
@@ -31,13 +30,6 @@ const Metadata = ({ metadata, handleChange, handleSubmit, uploadSuccess, isResou
           return handleSubmit(event, 0)
         }}
       >
-=======
-const Metadata = ({ metadata, handleChange, uploadSuccess }) => {
-  return (
-    <>
-      <h3 className="metadata-name">{metadata.path}</h3>
-      <form className="metadata-form">
->>>>>>> [ui][s] removed switcher and update css styles - #39
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="title">
             Title:

--- a/src/components/Metadata/index.jsx
+++ b/src/components/Metadata/index.jsx
@@ -16,20 +16,11 @@ const customFields = [
   },
 ];
 
-const Metadata = ({ metadata, handleChange, handleSubmit, uploadSuccess, isResourceEdit, deleteResource, updateResource}) => {
+const Metadata = ({ metadata, handleChange}) => {
   return (
     <>
       <h3 className="metadata-name">{metadata.path}</h3>
-      <form
-        className="metadata-form"
-        onSubmit={(event) => {
-          if (isResourceEdit) {
-            event.preventDefault();
-            return updateResource(metadata)
-          }
-          return handleSubmit(event, 0)
-        }}
-      >
+      <div className="metadata-form">
         <div className="metadata-input">
           <label className="metadata-label" htmlFor="title">
             Title:
@@ -128,21 +119,7 @@ const Metadata = ({ metadata, handleChange, handleSubmit, uploadSuccess, isResou
               </select>
             </div>
           ))}
-        {!isResourceEdit ? (
-          <button disabled={!uploadSuccess} className="metadata-btn">
-            Save and Publish
-          </button>
-        ) : (
-              <div>
-                <button type="button" className="btn btn-delete" onClick={deleteResource}>
-                  Delete
-                </button>
-                <button className="btn">
-                  Update
-                </button>
-              </div>
-        )}
-      </form>
+      </div>
     </>
   );
 };
@@ -150,10 +127,6 @@ const Metadata = ({ metadata, handleChange, handleSubmit, uploadSuccess, isResou
 Metadata.propTypes = {
   metadata: PropTypes.object.isRequired,
   handleChange: PropTypes.func.isRequired,
-  uploadSuccess: PropTypes.bool.isRequired,
-  isResourceEdit: PropTypes.bool.isRequired,
-  deleteResource: PropTypes.func.isRequired,
-  updateResource: PropTypes.func.isRequired,
 };
 
 export default Metadata;

--- a/src/components/TableSchema/TableSchema.css
+++ b/src/components/TableSchema/TableSchema.css
@@ -1,13 +1,19 @@
-.table {
+.table-schema-info {
   max-width: 585px;
   overflow: overlay;
   max-height: 675px;
+}
+
+.table-schema-info_table {
+  width: auto !important;
 }
 
 .table-container {
   display: flex;
   justify-content: center;
   justify-items: center;
+  margin-top: 2.6rem;
+  margin-bottom: 2rem;
 }
 
 .table-schema-help {

--- a/src/components/TableSchema/index.jsx
+++ b/src/components/TableSchema/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useTable } from "react-table";
 import types from "../../db/types.json";
@@ -8,13 +8,13 @@ import "./TableSchema.css";
 const TableSchema = (props) => {
   const [schema, setSchema] = useState(props.schema);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const data = React.useMemo(() => [...props.data], []);
+  const data = React.useMemo(() => [...props.data], [schema]);
 
   const columnsSchema = schema.fields.map((item, index) => {
     return { Header: item.name ? item.name : `column_${index + 1}`, accessor: item.name ? item.name : `column_${index + 1}`};
   });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const columns = React.useMemo(() => [...columnsSchema], []);
+  const columns = React.useMemo(() => [...columnsSchema], [schema]);
   const {
     getTableProps,
     getTableBodyProps,
@@ -28,6 +28,12 @@ const TableSchema = (props) => {
     newSchema.fields[index][key] = event.target.value;
     setSchema(newSchema);
   };
+
+  //if the the user upload a new file, will update the state
+  //and render with the new values
+  useEffect( () => { 
+    setSchema(props.schema);
+  }, [ props.schema ] );
 
   const renderEditSchemaField = (key) => {
     if (key === "type") {

--- a/src/components/TableSchema/index.jsx
+++ b/src/components/TableSchema/index.jsx
@@ -79,8 +79,8 @@ const TableSchema = (props) => {
           <div className="table-schema-help_row">Type</div>
           <div className="table-schema-help_row">Format</div>
         </div>
-        <div className="table">
-          <table {...getTableProps()}>
+        <div className="table-schema-info">
+          <table className="table-schema-info_table" {...getTableProps()}>
             <thead>
               {headerGroups.map((headerGroup) => (
                 <tr


### PR DESCRIPTION
Issue:  https://github.com/datopian/datapub/issues/39

- Removed the step process and show the schema editor always.
- add scroll table with the right widht to improve the style and in ckan-blob-storage
- removed background color and padding to improve the style in ckan-blob-storage
- moved the submit button to the app.js

Result:

![Screenshot from 2020-09-22 15-55-28](https://user-images.githubusercontent.com/24671133/93925142-126f8000-fcec-11ea-903c-fa4798c21355.png)
