### PR TITLE
Reduce level of "no parser" error to warning

### DIFF
--- a/src/components/Upload/index.jsx
+++ b/src/components/Upload/index.jsx
@@ -34,7 +34,7 @@ class Upload extends React.Component {
         file.descriptor.sample = await toArray(rowStream);
         await file.addSchema();
       } catch (e) {
-        console.error(e);
+        console.warn(e);
       }
       formattedSize = onFormatBytes(file.size);
       const hash = await file.hashSha256();


### PR DESCRIPTION
After all, execution continues here as the exception is caught, so this is most likely not critical. 
This resolves #72 by reducing the message level to a warning.